### PR TITLE
Change CC name from rally-cc -> Rally Creator Coin

### DIFF
--- a/contracts/RallyV1CreatorCoin.sol
+++ b/contracts/RallyV1CreatorCoin.sol
@@ -10,8 +10,10 @@ import "./RallyV1CreatorCoinFactory.sol";
 /// @title Creator Coin V1 ERC20
 /// @notice Single deployed ERC20 valid contract for each creator coin
 contract RallyV1CreatorCoin is
-  ERC20("rally-cc", "rcc"),
-  ERC20Permit("rally-cc"),
+  // note openzeppelin requires a static name and symbol but these are overridden with _name/_symbol
+  // (these strings do show up in the metamask permit modals etc though)
+  ERC20("Rally Creator Coin", "rcc"),
+  ERC20Permit("Rally Creator Coin"),
   ERC20Burnable
 {
   string private _sidechainPricingCurveId;

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -10,6 +10,8 @@ import '@nomiclabs/hardhat-waffle'
 import '@nomiclabs/hardhat-etherscan'
 import 'hardhat-abi-exporter'
 
+import './tasks/deployCC'
+
 const networks: NetworksUserConfig = {
   hardhat: {
     allowUnlimitedContractSize: false

--- a/tasks/deployCC.ts
+++ b/tasks/deployCC.ts
@@ -1,0 +1,88 @@
+import { task } from 'hardhat/config'
+import { HardhatRuntimeEnvironment } from 'hardhat/types'
+import { RallyV1CreatorCoinBridge } from '../typechain/RallyV1CreatorCoinBridge'
+import { RallyV1CreatorCoinFactory } from '../typechain/RallyV1CreatorCoinFactory'
+import { RallyV1CreatorCoin } from '../typechain/RallyV1CreatorCoin'
+import { BigNumber } from '@ethersproject/bignumber'
+
+/* e.g.
+npx hardhat --network localhost deployCC \
+--factory 0x5fbdb2315678afecb367f032d93f642f64180aa3 \
+--bridge 0xe7f1725e7734ce288f8367e1bb143e90bb3f0512 \
+--symbol JONO \
+--receiver 0x21c795b0d13b5c7434654062d98fce634795d70a \
+--amount 100
+*/
+task(
+  'deployCC',
+  'Deploys a fake CC for testing and mints `amount` coins to `receiver`'
+)
+  .addParam<string>('factory', 'factoryAddress')
+  .addParam<string>('bridge', 'bridgeAddress')
+  .addOptionalParam<string>('pricingcurveid', 'pricingCurveId')
+  .addOptionalParam<string>('name', 'name')
+  .addParam<string>('symbol', 'symbol')
+  .addParam<string>('receiver', 'receiverAddress')
+  .addOptionalParam<string>('amount', 'amount', '100')
+  .setAction(async (taskArgs: any, hre: HardhatRuntimeEnvironment) => {
+    if (hre.network.name === 'hardhat') {
+      console.warn(
+        'You are running the deployCC task with Hardhat network, which' +
+          'gets automatically created and destroyed every time. Use the Hardhat' +
+          " option '--network localhost'"
+      )
+    }
+
+    let {
+      factory: factoryAddress,
+      bridge: bridgeAddress,
+      pricingcurveid: pricingCurveId,
+      name,
+      symbol,
+      receiver: receiverAddress,
+      amount,
+    } = taskArgs
+
+    name = name || `${symbol} Coin`
+    pricingCurveId = pricingCurveId || `${symbol}fakePricingCurveId`
+
+    const factoryContract = (await hre.ethers.getContractAt(
+      'RallyV1CreatorCoinFactory',
+      factoryAddress
+    )) as RallyV1CreatorCoinFactory
+    const bridgeContract = (await hre.ethers.getContractAt(
+      'RallyV1CreatorCoinBridge',
+      bridgeAddress
+    )) as RallyV1CreatorCoinBridge
+
+    await factoryContract.deployCreatorCoin(pricingCurveId, name, symbol)
+
+    const coinAddress = await factoryContract.getCreatorCoinFromSidechainPricingCurveId(
+      pricingCurveId
+    )
+
+    const coinFactory = await hre.ethers.getContractFactory(
+      'RallyV1CreatorCoin'
+    )
+
+    const creatorCoin = coinFactory.attach(coinAddress) as RallyV1CreatorCoin
+
+    console.log('CC deployed')
+    console.log(
+      `Creator coin: ${name} (${symbol}) ${pricingCurveId} deployed to ${creatorCoin.address}`
+    )
+
+    const [signer] = await hre.ethers.getSigners()
+
+    await factoryContract.setBridge(signer.address)
+
+    // TODO: getSigner(bridge) doesn't work here? get "unknown account" error
+    await creatorCoin
+      .connect(signer)
+      .mint(
+        receiverAddress,
+        BigNumber.from(amount).mul(BigNumber.from(10).pow(6))
+      )
+
+    await factoryContract.setBridge(bridgeContract.address)
+  })

--- a/test/RallyV1CreatorCoin.spec.ts
+++ b/test/RallyV1CreatorCoin.spec.ts
@@ -76,7 +76,7 @@ describe('RallyV1CreatorCoin', () => {
 
   describe('#getters', () => {
     it('name and symbol are not the default from contract inheritance', async () => {
-      expect(creatorCoin.name()).to.eventually.not.eq('rally-cc')
+      expect(creatorCoin.name()).to.eventually.not.eq('Rally Creator Coin')
       expect(creatorCoin.symbol()).to.eventually.not.eq('rcc')
     })
 

--- a/test/RallyV1CreatorCoinBridge.spec.ts
+++ b/test/RallyV1CreatorCoinBridge.spec.ts
@@ -113,7 +113,7 @@ describe('RallyV1CreatorCoinBridge', () => {
     it('decreases balance and total supply', async () => {
       const amount = 100
       const domain = {
-        name: 'rally-cc',
+        name: 'Rally Creator Coin',
         version: '1',
         chainId: 31337,
         verifyingContract: creatorCoin.address


### PR DESCRIPTION
See https://github.com/starcard-org/coin-bridge-eth-scaffold/pull/9 for context/video

Also added a task that was helpful during testing that deploys and mints a CC (given a factory/bridge address and some other config)