### PR TITLE
Add option for custom decimals

### DIFF
--- a/abi/RallyV1CreatorCoinDeployer.json
+++ b/abi/RallyV1CreatorCoinDeployer.json
@@ -14,11 +14,6 @@
         "type": "bytes32"
       },
       {
-        "internalType": "uint8",
-        "name": "decimals",
-        "type": "uint8"
-      },
-      {
         "internalType": "string",
         "name": "sidechainPricingCurveId",
         "type": "string"
@@ -32,6 +27,11 @@
         "internalType": "string",
         "name": "symbol",
         "type": "string"
+      },
+      {
+        "internalType": "uint8",
+        "name": "decimals",
+        "type": "uint8"
       }
     ],
     "stateMutability": "view",

--- a/abi/RallyV1CreatorCoinDeployer.json
+++ b/abi/RallyV1CreatorCoinDeployer.json
@@ -14,6 +14,11 @@
         "type": "bytes32"
       },
       {
+        "internalType": "uint8",
+        "name": "decimals",
+        "type": "uint8"
+      },
+      {
         "internalType": "string",
         "name": "sidechainPricingCurveId",
         "type": "string"

--- a/abi/RallyV1CreatorCoinFactory.json
+++ b/abi/RallyV1CreatorCoinFactory.json
@@ -16,12 +16,6 @@
       },
       {
         "indexed": false,
-        "internalType": "uint8",
-        "name": "decimals",
-        "type": "uint8"
-      },
-      {
-        "indexed": false,
         "internalType": "string",
         "name": "sidechainPricingCurveId",
         "type": "string"
@@ -37,6 +31,12 @@
         "internalType": "string",
         "name": "symbol",
         "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "decimals",
+        "type": "uint8"
       }
     ],
     "name": "CreatorCoinDeployed",
@@ -106,11 +106,6 @@
   {
     "inputs": [
       {
-        "internalType": "uint8",
-        "name": "decimals",
-        "type": "uint8"
-      },
-      {
         "internalType": "string",
         "name": "sidechainPricingCurveId",
         "type": "string"
@@ -124,6 +119,11 @@
         "internalType": "string",
         "name": "symbol",
         "type": "string"
+      },
+      {
+        "internalType": "uint8",
+        "name": "decimals",
+        "type": "uint8"
       }
     ],
     "name": "deployCreatorCoinWithDecimals",
@@ -203,11 +203,6 @@
         "type": "bytes32"
       },
       {
-        "internalType": "uint8",
-        "name": "decimals",
-        "type": "uint8"
-      },
-      {
         "internalType": "string",
         "name": "sidechainPricingCurveId",
         "type": "string"
@@ -221,6 +216,11 @@
         "internalType": "string",
         "name": "symbol",
         "type": "string"
+      },
+      {
+        "internalType": "uint8",
+        "name": "decimals",
+        "type": "uint8"
       }
     ],
     "stateMutability": "view",

--- a/abi/RallyV1CreatorCoinFactory.json
+++ b/abi/RallyV1CreatorCoinFactory.json
@@ -16,6 +16,12 @@
       },
       {
         "indexed": false,
+        "internalType": "uint8",
+        "name": "decimals",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
         "internalType": "string",
         "name": "sidechainPricingCurveId",
         "type": "string"
@@ -100,6 +106,40 @@
   {
     "inputs": [
       {
+        "internalType": "uint8",
+        "name": "decimals",
+        "type": "uint8"
+      },
+      {
+        "internalType": "string",
+        "name": "sidechainPricingCurveId",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "name",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "symbol",
+        "type": "string"
+      }
+    ],
+    "name": "deployCreatorCoinWithDecimals",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "mainnetCreatorCoinAddress",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "string",
         "name": "sidechainPricingCurveId",
         "type": "string"
@@ -161,6 +201,11 @@
         "internalType": "bytes32",
         "name": "pricingCurveIdHash",
         "type": "bytes32"
+      },
+      {
+        "internalType": "uint8",
+        "name": "decimals",
+        "type": "uint8"
       },
       {
         "internalType": "string",

--- a/contracts/RallyV1CreatorCoin.sol
+++ b/contracts/RallyV1CreatorCoin.sol
@@ -9,8 +9,8 @@ import "./RallyV1CreatorCoinFactory.sol";
 
 /// @title Creator Coin V1 ERC20
 /// @notice Single deployed ERC20 valid contract for each creator coin
+// note openzeppelin requires a static name and symbol but these are overridden with _name/_symbol
 contract RallyV1CreatorCoin is
-  // note openzeppelin requires a static name and symbol but these are overridden with _name/_symbol
   ERC20("rally-cc", "rcc"),
   // this permit string shows up in the metamask signing modals so make it friendlier
   ERC20Permit("Rally Creator Coin"),
@@ -37,15 +37,17 @@ contract RallyV1CreatorCoin is
   }
 
   constructor() {
+    uint8 decimals;
     (
       factory,
       pricingCurveIdHash,
+      decimals,
       _sidechainPricingCurveId,
       _name,
       _symbol
     ) = RallyV1CreatorCoinDeployer(msg.sender).parameters();
 
-    _setupDecimals(6);
+    _setupDecimals(decimals);
   }
 
   /// @dev Returns the sidechain coin pricingCurveId.

--- a/contracts/RallyV1CreatorCoin.sol
+++ b/contracts/RallyV1CreatorCoin.sol
@@ -41,10 +41,10 @@ contract RallyV1CreatorCoin is
     (
       factory,
       pricingCurveIdHash,
-      decimals,
       _sidechainPricingCurveId,
       _name,
-      _symbol
+      _symbol,
+      decimals
     ) = RallyV1CreatorCoinDeployer(msg.sender).parameters();
 
     _setupDecimals(decimals);

--- a/contracts/RallyV1CreatorCoinDeployer.sol
+++ b/contracts/RallyV1CreatorCoinDeployer.sol
@@ -10,6 +10,7 @@ contract RallyV1CreatorCoinDeployer {
   struct Parameters {
     address factory;
     bytes32 pricingCurveIdHash;
+    uint8 decimals;
     string sidechainPricingCurveId;
     string name;
     string symbol;
@@ -32,6 +33,7 @@ contract RallyV1CreatorCoinDeployer {
   function deploy(
     address factory,
     bytes32 pricingCurveIdHash,
+    uint8 decimals,
     string memory sidechainPricingCurveId,
     string memory name,
     string memory symbol
@@ -39,6 +41,7 @@ contract RallyV1CreatorCoinDeployer {
     parameters = Parameters({
       factory: factory,
       pricingCurveIdHash: pricingCurveIdHash,
+      decimals: decimals,
       sidechainPricingCurveId: sidechainPricingCurveId,
       name: name,
       symbol: symbol

--- a/contracts/RallyV1CreatorCoinDeployer.sol
+++ b/contracts/RallyV1CreatorCoinDeployer.sol
@@ -10,10 +10,10 @@ contract RallyV1CreatorCoinDeployer {
   struct Parameters {
     address factory;
     bytes32 pricingCurveIdHash;
-    uint8 decimals;
     string sidechainPricingCurveId;
     string name;
     string symbol;
+    uint8 decimals;
   }
 
   /// @notice Get the parameters to be used in constructing the coin, set transiently during coin creation.
@@ -33,18 +33,18 @@ contract RallyV1CreatorCoinDeployer {
   function deploy(
     address factory,
     bytes32 pricingCurveIdHash,
-    uint8 decimals,
     string memory sidechainPricingCurveId,
     string memory name,
-    string memory symbol
+    string memory symbol,
+    uint8 decimals
   ) internal returns (address mainnetCreatorCoinAddress) {
     parameters = Parameters({
       factory: factory,
       pricingCurveIdHash: pricingCurveIdHash,
-      decimals: decimals,
       sidechainPricingCurveId: sidechainPricingCurveId,
       name: name,
-      symbol: symbol
+      symbol: symbol,
+      decimals: decimals
     });
 
     mainnetCreatorCoinAddress = address(

--- a/contracts/RallyV1CreatorCoinFactory.sol
+++ b/contracts/RallyV1CreatorCoinFactory.sol
@@ -14,16 +14,45 @@ contract RallyV1CreatorCoinFactory is Ownable, RallyV1CreatorCoinDeployer {
   event CreatorCoinDeployed(
     bytes32 pricingCurveIdHash,
     address indexed mainnetCreatorCoinAddress,
+    uint8 decimals,
     string sidechainPricingCurveId,
     string name,
     string symbol
   );
+
+  function deployCreatorCoinWithDecimals(
+    uint8 decimals,
+    string memory sidechainPricingCurveId,
+    string memory name,
+    string memory symbol
+  ) external onlyOwner returns (address mainnetCreatorCoinAddress) {
+    mainnetCreatorCoinAddress = _deployCreatorCoin(
+      decimals,
+      sidechainPricingCurveId,
+      name,
+      symbol
+    );
+  }
 
   function deployCreatorCoin(
     string memory sidechainPricingCurveId,
     string memory name,
     string memory symbol
   ) external onlyOwner returns (address mainnetCreatorCoinAddress) {
+    mainnetCreatorCoinAddress = _deployCreatorCoin(
+      6,
+      sidechainPricingCurveId,
+      name,
+      symbol
+    );
+  }
+
+  function _deployCreatorCoin(
+    uint8 decimals,
+    string memory sidechainPricingCurveId,
+    string memory name,
+    string memory symbol
+  ) internal returns (address mainnetCreatorCoinAddress) {
     bytes32 pricingCurveIdHash = keccak256(abi.encode(sidechainPricingCurveId));
 
     require(
@@ -34,6 +63,7 @@ contract RallyV1CreatorCoinFactory is Ownable, RallyV1CreatorCoinDeployer {
     mainnetCreatorCoinAddress = deploy(
       address(this),
       pricingCurveIdHash,
+      decimals,
       sidechainPricingCurveId,
       name,
       symbol
@@ -45,6 +75,7 @@ contract RallyV1CreatorCoinFactory is Ownable, RallyV1CreatorCoinDeployer {
     emit CreatorCoinDeployed(
       pricingCurveIdHash,
       mainnetCreatorCoinAddress,
+      decimals,
       sidechainPricingCurveId,
       name,
       symbol

--- a/contracts/RallyV1CreatorCoinFactory.sol
+++ b/contracts/RallyV1CreatorCoinFactory.sol
@@ -14,23 +14,23 @@ contract RallyV1CreatorCoinFactory is Ownable, RallyV1CreatorCoinDeployer {
   event CreatorCoinDeployed(
     bytes32 pricingCurveIdHash,
     address indexed mainnetCreatorCoinAddress,
-    uint8 decimals,
     string sidechainPricingCurveId,
     string name,
-    string symbol
+    string symbol,
+    uint8 decimals
   );
 
   function deployCreatorCoinWithDecimals(
-    uint8 decimals,
     string memory sidechainPricingCurveId,
     string memory name,
-    string memory symbol
+    string memory symbol,
+    uint8 decimals
   ) external onlyOwner returns (address mainnetCreatorCoinAddress) {
     mainnetCreatorCoinAddress = _deployCreatorCoin(
-      decimals,
       sidechainPricingCurveId,
       name,
-      symbol
+      symbol,
+      decimals
     );
   }
 
@@ -40,18 +40,18 @@ contract RallyV1CreatorCoinFactory is Ownable, RallyV1CreatorCoinDeployer {
     string memory symbol
   ) external onlyOwner returns (address mainnetCreatorCoinAddress) {
     mainnetCreatorCoinAddress = _deployCreatorCoin(
-      6,
       sidechainPricingCurveId,
       name,
-      symbol
+      symbol,
+      6
     );
   }
 
   function _deployCreatorCoin(
-    uint8 decimals,
     string memory sidechainPricingCurveId,
     string memory name,
-    string memory symbol
+    string memory symbol,
+    uint8 decimals
   ) internal returns (address mainnetCreatorCoinAddress) {
     bytes32 pricingCurveIdHash = keccak256(abi.encode(sidechainPricingCurveId));
 
@@ -63,10 +63,10 @@ contract RallyV1CreatorCoinFactory is Ownable, RallyV1CreatorCoinDeployer {
     mainnetCreatorCoinAddress = deploy(
       address(this),
       pricingCurveIdHash,
-      decimals,
       sidechainPricingCurveId,
       name,
-      symbol
+      symbol,
+      decimals
     );
 
     getMainnetCreatorCoinAddress[
@@ -75,10 +75,10 @@ contract RallyV1CreatorCoinFactory is Ownable, RallyV1CreatorCoinDeployer {
     emit CreatorCoinDeployed(
       pricingCurveIdHash,
       mainnetCreatorCoinAddress,
-      decimals,
       sidechainPricingCurveId,
       name,
-      symbol
+      symbol,
+      decimals
     );
   }
 

--- a/test/RallyV1CreatorCoinFactory.spec.ts
+++ b/test/RallyV1CreatorCoinFactory.spec.ts
@@ -208,7 +208,7 @@ describe('RallyV1CreatorCoinFactory', () => {
           coinPricingCurveId,
           name,
           symbol,
-          18
+          decimals
         )
       ).to.be.revertedWith('already deployed')
     })
@@ -235,7 +235,12 @@ describe('RallyV1CreatorCoinFactory', () => {
       await expect(
         factory
           .connect(other)
-          .deployCreatorCoinWithDecimals(coinPricingCurveId, name, symbol, 18)
+          .deployCreatorCoinWithDecimals(
+            coinPricingCurveId,
+            name,
+            symbol,
+            decimals
+          )
       ).to.be.revertedWith('caller is not the owner')
     })
   })

--- a/test/RallyV1CreatorCoinFactory.spec.ts
+++ b/test/RallyV1CreatorCoinFactory.spec.ts
@@ -20,7 +20,7 @@ describe('RallyV1CreatorCoinFactory', () => {
   }
 
   let loadFixture: ReturnType<typeof createFixtureLoader>
-  before('create fixture loader', async () => {
+  before('create fixture loader', () => {
     loadFixture = createFixtureLoader([wallet, other])
   })
 
@@ -34,7 +34,7 @@ describe('RallyV1CreatorCoinFactory', () => {
   })
 
   it('owner is deployer', async () => {
-    expect(factory.owner()).to.eventually.eq(wallet.address)
+    await expect(factory.owner()).to.eventually.eq(wallet.address)
   })
 
   xit('factory bytecode', async () => {
@@ -83,7 +83,7 @@ describe('RallyV1CreatorCoinFactory', () => {
 
     it('updates owner', async () => {
       await factory.transferOwnership(other.address)
-      expect(factory.owner()).to.eventually.eq(other.address)
+      await expect(factory.owner()).to.eventually.eq(other.address)
     })
 
     it('emits event', async () => {
@@ -106,7 +106,7 @@ describe('RallyV1CreatorCoinFactory', () => {
     let create2Address: string
     let create: Promise<ContractTransaction>
 
-    beforeEach('deploy factory', async () => {
+    beforeEach('deploy factory', () => {
       name = 'token'
       symbol = 'tkn'
       coinPricingCurveId = 'some-curve-id'
@@ -143,7 +143,7 @@ describe('RallyV1CreatorCoinFactory', () => {
     })
 
     it('factory address matches calculated address', async () => {
-      expect(
+      await expect(
         factory.getCreatorCoinFromSidechainPricingCurveId(coinPricingCurveId)
       ).to.eventually.eq(create2Address)
     })
@@ -166,7 +166,7 @@ describe('RallyV1CreatorCoinFactory', () => {
     let create2Address: string
     let create: Promise<ContractTransaction>
 
-    beforeEach('deploy factory', async () => {
+    beforeEach('deploy factory', () => {
       decimals = 18
       name = 'token'
       symbol = 'tkn'
@@ -214,7 +214,7 @@ describe('RallyV1CreatorCoinFactory', () => {
     })
 
     it('factory address matches calculated address', async () => {
-      expect(
+      await expect(
         factory.getCreatorCoinFromSidechainPricingCurveId(coinPricingCurveId)
       ).to.eventually.eq(create2Address)
     })
@@ -228,7 +228,7 @@ describe('RallyV1CreatorCoinFactory', () => {
         waffle.provider
       ) as RallyV1CreatorCoin
 
-      expect(cc.decimals()).to.eventually.eq(decimals)
+      await expect(cc.decimals()).to.eventually.eq(decimals)
     })
 
     it('fails if not owner', async () => {


### PR DESCRIPTION
This will keep the original method `deployCreatorCoin` which will deploy with 6 decimals to match the sidechain but adds an additional `deployCreatorCoinWithDecimals` method for the future case where we want to customize the decimals.

Method signatures for the old function remained unchained and old generated abis will still function correctly with the exception of not having the new `deployCreatorCoinWithDecimals` method.